### PR TITLE
Support for exporting related records.

### DIFF
--- a/php-classes/CSV.class.php
+++ b/php-classes/CSV.class.php
@@ -28,18 +28,24 @@ class CSV
 			$columnNames = array_keys($firstRecord);
             $columnNames = array_combine($columnNames, $columnNames);
 		} else {
-			$columnNames = array_keys(JSON::translateObjects($firstRecord, false, $columns, true));
+            
+            $dynamicFields = $firstRecord->aggregateStackedConfig('dynamicFields');
+            $fields = $firstRecord->aggregateStackedConfig('fields');
+            
+            $columnNames = array_merge(array_keys($fields), array_keys($dynamicFields));
             $columnNames = array_combine($columnNames, $columnNames);
             
             foreach ($columnNames AS &$columnName) {
-                if (($dynamicField = $firstRecord->getStackedConfig('dynamicFields', $columnName)) && !empty($dynamicField['label'])) {
+                $dynamicField = $dynamicFields[$columnName];
+                $field = $fields[$columnName];
+                
+                if ($dynamicField && !empty($dynamicField['label'])) {
                     $columnName = $dynamicField['label'];
-                } elseif(($field = $firstRecord->getStackedConfig('fields', $columnName)) && !empty($field['label'])) {
+                } elseif($field && !empty($field['label'])) {
                     $columnName = $field['label'];
                 }
             }
 		}
-
 		$csv = static::rowFromArray($columnNames, $columns);
 		
 		foreach ($records AS $record) {			


### PR DESCRIPTION
This update fixed the current problem, where exporting multiple classes (i.e. Emergence\People\Person & Emergence\People\User) would only include the fields of the first record in the dataset.